### PR TITLE
fixed missing include

### DIFF
--- a/src/board/base.cpp
+++ b/src/board/base.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 
 #include "base.h"
 #include "chess.h"


### PR DESCRIPTION
std::count is a part of algorithm, which is missing.